### PR TITLE
chore: prep 0.8.1 release — slim README, harden flaky Jupyter UI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,63 +6,30 @@ popular Python spatial packages.
 
 ![pyglobegl rendering a population hex-bin layer on the globe](https://raw.githubusercontent.com/owenlamont/pyglobegl/main/docs/images/layers/hex-bin.png)
 
+📖 **Full documentation: <https://pyglobegl.pages.dev/>**
+
+pyglobegl renders interactive WebGL globes in modern notebook environments
+(Jupyter, JupyterLab, Colab, VS Code, marimo) and drives them from a friendly,
+strongly typed Python API. It ships a prebuilt JupyterLab extension, so
+`pip install` is all you need.
+
 ## Installation
 
 ```bash
 pip install pyglobegl
 ```
 
-Or with uv:
+Optional spatial extras:
 
 ```bash
-uv add pyglobegl
+pip install "pyglobegl[geopandas]"     # GeoPandas + Pandera helpers
+pip install "pyglobegl[movingpandas]"  # MovingPandas (includes GeoPandas)
 ```
 
-Optional GeoPandas + Pandera extra:
+See the [installation guide](https://pyglobegl.pages.dev/getting-started/installation/)
+for uv and extras details.
 
-```bash
-pip install pyglobegl[geopandas]
-```
-
-```bash
-uv add pyglobegl[geopandas]
-```
-
-Optional MovingPandas extra (includes GeoPandas + Pandera):
-
-```bash
-pip install pyglobegl[movingpandas]
-```
-
-```bash
-uv add pyglobegl[movingpandas]
-```
-
-## Quickstart
-
-```python
-from IPython.display import display
-
-from pyglobegl import GlobeWidget
-
-display(GlobeWidget())
-```
-
-## Image Inputs
-
-Globe image fields expect URLs, but you can pass a PIL image by converting it
-to a PNG data URL:
-
-```python
-from PIL import Image
-
-from pyglobegl import GlobeLayerConfig, image_to_data_url
-
-image = Image.open("earth.png")
-config = GlobeLayerConfig(globe_image_url=image_to_data_url(image))
-```
-
-## Points Layer
+## Quick start
 
 ```python
 from IPython.display import display
@@ -90,690 +57,52 @@ config = GlobeConfig(
 display(GlobeWidget(config=config))
 ```
 
-pyglobegl expects layer data as Pydantic models (for example: `PointDatum`,
-`ArcDatum`, `PolygonDatum`, `PathDatum`, `HeatmapDatum`, `HexBinPointDatum`,
-`HexPolygonDatum`, `TileDatum`, `ParticleDatum`, `RingDatum`, `LabelDatum`).
-Dynamic accessor remapping is not supported; per-datum values are read from the
-model field names. Numeric fields reject string values, and data model defaults
-mirror globe.gl defaults so omitted values still render predictably.
-
-## Arcs Layer
-
-```python
-from IPython.display import display
-
-from pyglobegl import (
-    ArcDatum,
-    ArcsLayerConfig,
-    GlobeConfig,
-    GlobeLayerConfig,
-    GlobeWidget,
-)
-
-arcs = [
-    ArcDatum(
-        start_lat=0,
-        start_lng=-30,
-        end_lat=10,
-        end_lng=40,
-        altitude=0.2,
-        color="#ffcc00",
-        stroke=1.2,
-    ),
-    ArcDatum(
-        start_lat=20,
-        start_lng=10,
-        end_lat=-10,
-        end_lng=-50,
-        altitude=0.1,
-        color="#ffcc00",
-        stroke=1.2,
-    ),
-]
-
-config = GlobeConfig(
-    globe=GlobeLayerConfig(
-        globe_image_url="https://cdn.jsdelivr.net/npm/three-globe/example/img/earth-day.jpg"
-    ),
-    arcs=ArcsLayerConfig(arcs_data=arcs),
-)
-
-display(GlobeWidget(config=config))
-```
-
-## Polygons Layer
-
-```python
-from IPython.display import display
-from geojson_pydantic import Polygon
-
-from pyglobegl import (
-    GlobeConfig,
-    GlobeLayerConfig,
-    GlobeWidget,
-    PolygonDatum,
-    PolygonsLayerConfig,
-)
-
-polygon = Polygon(
-    type="Polygon",
-    coordinates=[
-        [
-            (-10, 0),
-            (-10, 10),
-            (10, 10),
-            (10, 0),
-            (-10, 0),
-        ]
-    ],
-)
-
-config = GlobeConfig(
-    globe=GlobeLayerConfig(
-        globe_image_url="https://cdn.jsdelivr.net/npm/three-globe/example/img/earth-day.jpg"
-    ),
-    polygons=PolygonsLayerConfig(
-        polygons_data=[
-            PolygonDatum(geometry=polygon, cap_color="#ffcc00", altitude=0.05)
-        ],
-    ),
-)
-
-display(GlobeWidget(config=config))
-```
-
-### Paths Example
-
-```python
-from pyglobegl import GlobeConfig, GlobeWidget, PathDatum, PathsLayerConfig
-
-paths = [
-    PathDatum(
-        path=[(0, 0), (5, 5), (10, 0)], color="#66ccff", dash_length=0.02
-    ),
-]
-
-config = GlobeConfig(
-    paths=PathsLayerConfig(paths_data=paths, path_transition_duration=0),
-)
-
-display(GlobeWidget(config=config))
-```
-
-## Heatmaps Layer
-
-```python
-from pyglobegl import (
-    GlobeConfig,
-    GlobeWidget,
-    HeatmapDatum,
-    HeatmapPointDatum,
-    HeatmapsLayerConfig,
-)
-
-heatmap = HeatmapDatum(
-    points=[
-        HeatmapPointDatum(lat=0, lng=0, weight=1.0),
-        HeatmapPointDatum(lat=10, lng=10, weight=0.6),
-    ],
-    bandwidth=0.8,
-    color_saturation=2.5,
-)
-
-config = GlobeConfig(heatmaps=HeatmapsLayerConfig(heatmaps_data=[heatmap]))
-
-display(GlobeWidget(config=config))
-```
-
-## Hex Bin Layer (MicroPython Accessors)
-
-```python
-from pyglobegl import (
-    GlobeConfig,
-    GlobeWidget,
-    HexBinLayerConfig,
-    HexBinPointDatum,
-    frontend_python,
-)
-
-
-@frontend_python
-def hex_altitude(hexbin):
-    return hexbin["sumWeight"] * 0.01
-
-
-@frontend_python
-def point_weight(point):
-    # point is an individual input row from hex_bin_points_data
-    return point["weight"] * 2.0
-
-
-@frontend_python
-def hex_color(hexbin):
-    return "#ff5500" if hexbin["sumWeight"] > 2 else "#66ccff"
-
-
-@frontend_python
-def hex_label(hexbin):
-    return f"<b>{len(hexbin['points'])}</b> points in this hex bin"
-
-
-points = [
-    HexBinPointDatum(lat=0, lng=0, weight=1.0),
-    HexBinPointDatum(lat=12, lng=15, weight=3.5),
-]
-
-config = GlobeConfig(
-    hex_bin=HexBinLayerConfig(
-        hex_bin_points_data=points,
-        hex_bin_point_weight=point_weight,
-        hex_altitude=hex_altitude,
-        hex_top_color=hex_color,
-        hex_side_color=hex_color,
-        hex_label=hex_label,
-    )
-)
-
-display(GlobeWidget(config=config))
-```
-
-Frontend callback arguments are normalized to plain Python values (dict/list/
-str/float/bool/None) when they are JSON-serializable, so dict methods like
-`.get(...)` work in callbacks such as `hex_label`.
-
-Hexbin callback I/O guide:
-
-- `hex_bin_point_lat(point) -> float`: `point` is one row from `hex_bin_points_data`.
-- `hex_bin_point_lng(point) -> float`: `point` is one row from `hex_bin_points_data`.
-- `hex_bin_point_weight(point) -> float`: `point` is one row from `hex_bin_points_data`.
-- `hex_top_color(hexbin) -> str`: CSS color string.
-- `hex_side_color(hexbin) -> str`: CSS color string.
-- `hex_altitude(hexbin) -> float`: non-negative altitude in globe-radius units.
-- `hex_label(hexbin) -> str`: HTML/text tooltip content.
-
-The `hexbin` argument shape is:
-`{"h3Idx": str, "points": list[dict], "sumWeight": float}`.
-For compatibility across upstream changes, prefer defensive access (for example,
-`hexbin.get("sumWeight", 0)`) in case keys are missing or values change shape.
-
-`hex_margin`, `hex_bin_point_lat`, `hex_bin_point_lng`, and
-`hex_bin_point_weight` also accept `@frontend_python` callbacks when you need
-frontend-computed accessors without writing JavaScript.
-
-## Hexed Polygons Layer
-
-```python
-from geojson_pydantic import Polygon
-
-from pyglobegl import (
-    GlobeConfig,
-    GlobeWidget,
-    HexPolygonDatum,
-    HexedPolygonsLayerConfig,
-)
-
-geometry = Polygon(
-    type="Polygon",
-    coordinates=[
-        [(-10, 0), (-10, 10), (10, 10), (10, 0), (-10, 0)],
-    ],
-)
-
-hexed = [
-    HexPolygonDatum(geometry=geometry, color="#ffcc00", altitude=0.05),
-]
-
-config = GlobeConfig(
-    hexed_polygons=HexedPolygonsLayerConfig(hex_polygons_data=hexed)
-)
-
-display(GlobeWidget(config=config))
-```
-
-## Tiles Layer
-
-```python
-from pyglobegl import (
-    GlobeConfig,
-    GlobeMaterialSpec,
-    GlobeWidget,
-    TileDatum,
-    TilesLayerConfig,
-)
-
-tiles = [
-    TileDatum(
-        lat=0,
-        lng=0,
-        width=10,
-        height=10,
-        material=GlobeMaterialSpec(
-            type="MeshLambertMaterial",
-            params={"color": "#66ccff", "opacity": 0.6, "transparent": True},
-        ),
-    )
-]
-
-config = GlobeConfig(tiles=TilesLayerConfig(tiles_data=tiles))
-
-display(GlobeWidget(config=config))
-```
-
-## Particles Layer
-
-```python
-from pyglobegl import (
-    GlobeConfig,
-    GlobeWidget,
-    ParticleDatum,
-    ParticlePointDatum,
-    ParticlesLayerConfig,
-)
-
-particles = [
-    ParticleDatum(
-        particles=[
-            ParticlePointDatum(lat=0, lng=0, altitude=0.2, label="Alpha"),
-            ParticlePointDatum(lat=10, lng=10, altitude=0.2, label="Beta"),
-        ],
-        color="palegreen",
-        size=2.0,
-    )
-]
-
-config = GlobeConfig(particles=ParticlesLayerConfig(particles_data=particles))
-
-display(GlobeWidget(config=config))
-```
-
-## Rings Layer
-
-```python
-from pyglobegl import GlobeConfig, GlobeWidget, RingDatum, RingsLayerConfig
-
-rings = [
-    RingDatum(lat=0, lng=0, max_radius=4, color="#ff66cc"),
-    RingDatum(lat=20, lng=10, max_radius=6, color="#66ccff"),
-]
-
-config = GlobeConfig(rings=RingsLayerConfig(rings_data=rings))
-
-display(GlobeWidget(config=config))
-```
-
-## Labels Layer
-
-```python
-from pyglobegl import GlobeConfig, GlobeWidget, LabelDatum, LabelsLayerConfig
-
-labels = [
-    LabelDatum(lat=0, lng=0, text="Center", color="#ffcc00"),
-    LabelDatum(lat=15, lng=20, text="North", color="#66ccff", include_dot=True),
-]
-
-config = GlobeConfig(labels=LabelsLayerConfig(labels_data=labels))
-
-display(GlobeWidget(config=config))
-```
-
-## Runtime Updates and Callbacks
-
-Use `GlobeWidget` setters to update data and accessors after the widget is
-rendered. Each datum includes an auto-generated UUID4 `id` unless provided.
-Callback payloads include the datum (and its `id`) so you can update visuals in
-response to user input.
-Runtime update helpers validate UUID4 ids; invalid ids raise a validation error.
-Batch updates use the patch models (`PointDatumPatch`, `ArcDatumPatch`,
-`PolygonDatumPatch`, `PathDatumPatch`, `HeatmapDatumPatch`,
-`HexPolygonDatumPatch`, `TileDatumPatch`, `ParticleDatumPatch`,
-`RingDatumPatch`, `LabelDatumPatch`) so updates are
-serialized with the correct globe.gl field names.
-
-```python
-widget = GlobeWidget(config=config)
-display(widget)
-
-def on_polygon_hover(current, previous):
-    if previous:
-        widget.update_polygon(
-            previous["id"],
-            cap_color=previous["base_color"],
-            altitude=previous["altitude"],
-        )
-    if current:
-        widget.update_polygon(
-            current["id"],
-            cap_color="#2f80ff",
-            altitude=current["altitude"] + 0.03,
-        )
-
-widget.on_polygon_hover(on_polygon_hover)
-```
-
-Hover callbacks are only wired when you register a hover handler. This avoids
-continuous hover traffic for layers you are not interacting with, and matches
-globe.gl behavior (no hover cursor when no hover callback is registered).
-
-## GeoPandas Helpers (Optional)
-
-Convert GeoDataFrames into layer data using Pandera DataFrameModel validation.
-These helpers return Pydantic models (`PointDatum`, `ArcDatum`, `PolygonDatum`,
-`PathDatum`, `HeatmapDatum`, `HexPolygonDatum`, `TileDatum`, `ParticleDatum`,
-`RingDatum`, `LabelDatum`).
-Point geometries are reprojected to EPSG:4326 before extracting lat/lng.
-`points_from_gdf` defaults to a point geometry column named `point` if present,
-otherwise it uses the active GeoDataFrame geometry column (override with
-`point_geometry=`). `arcs_from_gdf` expects point geometry columns named
-`start` and `end` (override with `start_geometry=` and `end_geometry=`).
-`polygons_from_gdf` defaults to a geometry column named `polygons` if present,
-otherwise it uses the active GeoDataFrame geometry column (override with
-`geometry_column=`). `paths_from_gdf` defaults to a geometry column named
-`paths` if present, otherwise it uses the active GeoDataFrame geometry column
-(override with `geometry_column=`).
-
-### Points Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Point
-
-from pyglobegl import points_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "name": ["A", "B"],
-        "population": [1000, 2000],
-        "point": [Point(0, 0), Point(5, 5)],
-    },
-    geometry="point",
-    crs="EPSG:4326",
-)
-points = points_from_gdf(gdf, include_columns=["name", "population"])
-```
-
-### Arcs Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Point
-
-from pyglobegl import arcs_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "name": ["Route A", "Route B"],
-        "value": [1, 2],
-        "start": [Point(0, 0), Point(10, 5)],
-        "end": [Point(20, 10), Point(-5, -5)],
-    },
-    geometry="start",
-    crs="EPSG:4326",
-)
-arcs = arcs_from_gdf(gdf, include_columns=["name", "value"])
-```
-
-### Polygons Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Polygon
-
-from pyglobegl import polygons_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "name": ["Zone A"],
-        "polygons": [
-            Polygon([(-10, 0), (-10, 10), (10, 10), (10, 0), (-10, 0)]),
-        ],
-    },
-    geometry="polygons",
-    crs="EPSG:4326",
-)
-polygons = polygons_from_gdf(gdf, include_columns=["name"])
-```
-
-### Paths Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import LineString
-
-from pyglobegl import paths_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "name": ["Route A"],
-        "paths": [LineString([(0, 0), (5, 5), (10, 0)])],
-    },
-    geometry="paths",
-    crs="EPSG:4326",
-)
-paths = paths_from_gdf(gdf, include_columns=["name"])
-```
-
-### Heatmaps Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Point
-
-from pyglobegl import heatmaps_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "weight": [1.0, 0.6],
-        "point": [Point(0, 0), Point(10, 10)],
-    },
-    geometry="point",
-    crs="EPSG:4326",
-)
-heatmaps = heatmaps_from_gdf(gdf, weight_column="weight", bandwidth=0.8)
-```
-
-### Hex Bin Points Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Point
-
-from pyglobegl import hexbin_points_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "population": [2_100_000, 450_000],
-        "point": [Point(0, 0), Point(10, 10)],
-    },
-    geometry="point",
-    crs="EPSG:4326",
-)
-hex_points = hexbin_points_from_gdf(gdf, weight_column="population")
-```
-
-### Hexed Polygons Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Polygon
-
-from pyglobegl import hexed_polygons_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "name": ["Zone A"],
-        "polygons": [
-            Polygon([(-10, 0), (-10, 10), (10, 10), (10, 0), (-10, 0)]),
-        ],
-    },
-    geometry="polygons",
-    crs="EPSG:4326",
-)
-hexed = hexed_polygons_from_gdf(gdf, include_columns=["name"])
-```
-
-### Tiles Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Point
-
-from pyglobegl import tiles_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "width": [10.0],
-        "height": [10.0],
-        "point": [Point(0, 0)],
-    },
-    geometry="point",
-    crs="EPSG:4326",
-)
-tiles = tiles_from_gdf(gdf, include_columns=["width", "height"])
-```
-
-### Particles Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Point
-
-from pyglobegl import particles_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "altitude": [0.2, 0.2],
-        "point": [Point(0, 0), Point(10, 10)],
-    },
-    geometry="point",
-    crs="EPSG:4326",
-)
-particles = particles_from_gdf(
-    gdf, altitude_column="altitude", color="palegreen"
-)
-```
-
-### Rings Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Point
-
-from pyglobegl import rings_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "max_radius": [4.0, 6.0],
-        "color": ["#ff66cc", "#66ccff"],
-        "point": [Point(0, 0), Point(20, 10)],
-    },
-    geometry="point",
-    crs="EPSG:4326",
-)
-rings = rings_from_gdf(gdf, include_columns=["max_radius", "color"])
-```
-
-### Labels Example
-
-```python
-import geopandas as gpd
-from shapely.geometry import Point
-
-from pyglobegl import labels_from_gdf
-
-gdf = gpd.GeoDataFrame(
-    {
-        "text": ["Center", "North"],
-        "color": ["#ffcc00", "#66ccff"],
-        "point": [Point(0, 0), Point(15, 20)],
-    },
-    geometry="point",
-    crs="EPSG:4326",
-)
-labels = labels_from_gdf(gdf, include_columns=["color"])
-```
-
-## MovingPandas Helpers (Optional)
-
-### MovingPandas Example
-
-```python
-import geopandas as gpd
-import movingpandas as mpd
-import pandas as pd
-from shapely.geometry import Point
-
-from pyglobegl import paths_from_mpd
-
-df = pd.DataFrame(
-    [
-        {"geometry": Point(0, 0), "t": pd.Timestamp("2023-01-01 12:00:00")},
-        {"geometry": Point(1, 1), "t": pd.Timestamp("2023-01-01 12:01:00")},
-        {"geometry": Point(2, 0), "t": pd.Timestamp("2023-01-01 12:02:00")},
-    ]
-).set_index("t")
-gdf = gpd.GeoDataFrame(df, crs="EPSG:4326")
-traj = mpd.Trajectory(gdf, 1)
-
-paths = paths_from_mpd(traj)
-```
-
-## Goals
-
-- Provide a modern AnyWidget-based globe.gl wrapper for Jupyter, JupyterLab,
-  Colab, VS Code, and marimo.
-- Ship a prebuilt JupyterLab extension via pip install (no separate lab
-  build/extension install).
-- Keep the Python API friendly for spatial data workflows.
-
-## Roadmap
-
-- **Near term**
-  - Expose globe.gl APIs in order (by section):
-    - [x] Initialisation
-    - [x] Container layout
-    - [x] Globe layer
-    - [x] Points layer
-    - [x] Arcs layer
-    - [x] Polygons layer
-    - [x] Paths layer
-    - [x] Heatmaps layer
-    - [x] Hex bin layer
-    - [x] Hexed polygons layer
-    - [x] Tiles layer
-    - [x] Particles layer
-    - [x] Rings layer
-    - [x] Labels layer
-    - [ ] HTML elements layer
-    - [ ] 3D objects layer
-    - [ ] Custom layer
-    - [ ] Render control
-    - [ ] Utility options
-  - Prioritize strongly typed, overload-heavy Python APIs with flexible input
-    unions (e.g., accept Pillow images, NumPy arrays, or remote URLs anywhere
-    globe.gl accepts textures/images).
-  - Solidify a CRS-first API: detect CRS on inputs and auto-reproject to
-    EPSG:4326 before emitting lat/lng data for globe.gl layers.
-
-- **Mid term**
-  - GeoPandas adapter: map geometry types to globe.gl layers with sensible
-    defaults and schema validation.
-  - MovingPandas trajectories (static): accept trajectory/segment outputs and
-    render via paths/arcs without time animation in v1.
-  - Geometry-only inputs: accept bare geometry collections (Shapely or
-    GeoJSON-like) as a convenience layer when CRS metadata is explicit.
-
-- **Long term / research**
-  - GeoPolars exploration: track maturity and define an adapter plan once CRS
-    metadata and extension types are stable upstream.
-  - Raster feasibility: investigate mapping rasters to globe.gl via tiles,
-    heatmaps, or sampled grids; document constraints and recommended workflows.
+Layer data are typed Pydantic models (no dynamic accessor remapping), and
+defaults mirror globe.gl so omitted values still render predictably. See the
+[quick start](https://pyglobegl.pages.dev/getting-started/quickstart/) for more.
+
+## Layers & features
+
+Each globe.gl layer is exposed as typed data models:
+
+- [Globe & images](https://pyglobegl.pages.dev/layers/globe/)
+- [Points](https://pyglobegl.pages.dev/layers/points/)
+- [Arcs](https://pyglobegl.pages.dev/layers/arcs/)
+- [Polygons](https://pyglobegl.pages.dev/layers/polygons/)
+- [Paths](https://pyglobegl.pages.dev/layers/paths/)
+- [Heatmaps](https://pyglobegl.pages.dev/layers/heatmaps/)
+- [Hex bin](https://pyglobegl.pages.dev/layers/hex-bin/)
+- [Hexed polygons](https://pyglobegl.pages.dev/layers/hexed-polygons/)
+- [Tiles](https://pyglobegl.pages.dev/layers/tiles/)
+- [Particles](https://pyglobegl.pages.dev/layers/particles/)
+- [Rings](https://pyglobegl.pages.dev/layers/rings/)
+- [Labels](https://pyglobegl.pages.dev/layers/labels/)
+
+Plus:
+
+- [Runtime updates & callbacks](https://pyglobegl.pages.dev/guides/runtime-updates/)
+  — update data and respond to hover/click after render
+- [Frontend Python callbacks](https://pyglobegl.pages.dev/guides/frontend-callbacks/)
+  — `@frontend_python` accessors that run in the browser
+- [GeoPandas helpers](https://pyglobegl.pages.dev/integrations/geopandas/)
+  — build layer data straight from GeoDataFrames
+- [MovingPandas helpers](https://pyglobegl.pages.dev/integrations/movingpandas/)
+  — render trajectories as paths
+
+## Documentation
+
+- [Getting started](https://pyglobegl.pages.dev/getting-started/installation/)
+- [Layers](https://pyglobegl.pages.dev/layers/globe/)
+- [Guides](https://pyglobegl.pages.dev/guides/runtime-updates/)
+- [Integrations](https://pyglobegl.pages.dev/integrations/geopandas/)
+- [Goals & roadmap](https://pyglobegl.pages.dev/about/roadmap/)
 
 ## Contributing
 
 ### Build Assets (Release Checklist)
 
-1) `cd frontend && pnpm run build`
-2) `uv build`
+1. `cd frontend && pnpm run build`
+2. `uv build`
 
 ### UI Test Artifacts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyglobegl"
-version = "0.8.0"
+version = "0.8.1"
 description = "anywidget wrapper for globe.gl"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dev = [
     "pytest-xdist>=3.8.0",
     "scikit-image>=0.25.2",
     "sgp4>=2.25",
+    "stamina>=26.1.0",
 ]
 docs = [
     "zensical>=0.0.43",

--- a/tests/test_ui_jupyter.py
+++ b/tests/test_ui_jupyter.py
@@ -14,6 +14,7 @@ import urllib.request
 
 from playwright.sync_api import Error as PlaywrightError
 import pytest
+import stamina
 
 
 if TYPE_CHECKING:
@@ -102,23 +103,54 @@ def _execute_cell(page, notebook, cell_text: str):
     return cell
 
 
-def _wait_for_canvas(page, cell, timeout_ms: int = 60000) -> None:
+def _cell_error_text(cell) -> str:
+    """Return the cell's stderr/traceback output text, if any."""
+    stderr = cell.locator(
+        ".jp-OutputArea-output[data-mime-type='application/vnd.jupyter.stderr']"
+    )
+    if stderr.count() > 0:
+        return "\n".join(stderr.all_inner_texts()).strip()
+    return ""
+
+
+def _wait_for_canvas(page, cell, timeout_ms: int = 30000) -> None:
+    """Wait for a sized canvas in the cell output.
+
+    Raises:
+        RuntimeError: The cell produced a traceback (a deterministic failure
+            that should not be retried).
+        TimeoutError: The canvas never attached or never gained a size (the
+            retryable, browser-timing failure).
+    """
     output = cell.locator(".jp-OutputArea")
     output.wait_for(state="attached", timeout=timeout_ms)
-    output_text = output.locator(".jp-OutputArea-output")
-    if output_text.count() > 0:
-        text = "\n".join(output_text.all_inner_texts()).strip()
-        if text:
-            raise RuntimeError(f"Cell output error:\n{text}")
+    error = _cell_error_text(cell)
+    if error:
+        raise RuntimeError(f"Cell output error:\n{error}")
     canvas = output.locator("canvas").first
     canvas.wait_for(state="attached", timeout=timeout_ms)
-    deadline = time.monotonic() + timeout_ms / 1000
+    deadline = time.monotonic() + 10
     while time.monotonic() < deadline:
         box = canvas.bounding_box()
         if box and box["width"] > 0 and box["height"] > 0:
             return
         page.wait_for_timeout(250)
-    raise TimeoutError("Canvas never became visible.")
+    raise TimeoutError("Canvas attached but never became visible.")
+
+
+def _render_widget(page, notebook, cell_text) -> None:
+    """Run the widget cell, re-running it until a canvas renders.
+
+    Rendering in CI occasionally misses a cell-execution state change, so the
+    fix is to re-run the cell (not wait longer). A cell traceback raises
+    ``RuntimeError``, which is not retried.
+    """
+    for attempt in stamina.retry_context(
+        on=(PlaywrightError, TimeoutError), attempts=3, timeout=None
+    ):
+        with attempt:
+            cell = _execute_cell(page, notebook, cell_text)
+            _wait_for_canvas(page, cell)
 
 
 def _assert_no_root_overflow(page) -> None:
@@ -283,7 +315,9 @@ def _jupyterlab_server() -> Iterator[str]:
         _shutdown_process(proc, log_file)
 
 
+@pytest.mark.timeout(240)
 def test_jupyter_widget_renders(page: "Page", ui_artifacts_writer) -> None:
+    cell_text = "from pyglobegl import GlobeWidget"
     with _jupyterlab_server() as url:
         try:
             _goto_with_retry(page, url)
@@ -293,16 +327,11 @@ def test_jupyter_widget_renders(page: "Page", ui_artifacts_writer) -> None:
             _select_kernel_if_prompted(page)
             _wait_for_kernel_idle(page)
             notebook = page.locator(".jp-NotebookPanel").first
-            notebook.get_by_text(
-                "from pyglobegl import GlobeWidget", exact=True
-            ).wait_for(timeout=60000)
-            cell = _execute_cell(page, notebook, "from pyglobegl import GlobeWidget")
+            notebook.get_by_text(cell_text, exact=True).wait_for(timeout=60000)
+            _execute_cell(page, notebook, cell_text)
             if _select_kernel_from_dialog(page):
                 _wait_for_kernel_idle(page)
-                cell = _execute_cell(
-                    page, notebook, "from pyglobegl import GlobeWidget"
-                )
-            _wait_for_canvas(page, cell)
+            _render_widget(page, notebook, cell_text)
             _assert_no_root_overflow(page)
         except Exception:
             try:

--- a/uv.lock
+++ b/uv.lock
@@ -2990,7 +2990,7 @@ wheels = [
 
 [[package]]
 name = "pyglobegl"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/uv.lock
+++ b/uv.lock
@@ -3031,6 +3031,7 @@ dev = [
     { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sgp4" },
+    { name = "stamina" },
 ]
 docs = [
     { name = "zensical" },
@@ -3070,6 +3071,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "sgp4", specifier = ">=2.25" },
+    { name = "stamina", specifier = ">=26.1.0" },
 ]
 docs = [{ name = "zensical", specifier = ">=0.0.43" }]
 
@@ -4292,6 +4294,18 @@ wheels = [
 ]
 
 [[package]]
+name = "stamina"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/bd/b2f71ae14368a066f103d182f25bbc6c3bf4aa695889f3ed3cba026d6f36/stamina-26.1.0.tar.gz", hash = "sha256:0214d05fdf5102c518194a4aac7520ce53cf660550ae3b940701aad88cf50c17", size = 568171, upload-time = "2026-04-13T17:44:31.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/f0/1ff90a1d1dd02de23feafdf9dffaecef3958348be5c192df56670ccb4f86/stamina-26.1.0-py3-none-any.whl", hash = "sha256:62e06829bec87c06d4cafde520b32a6097d1017c378a9eb63253c5bf5ebbbb88", size = 18508, upload-time = "2026-04-13T17:44:29.545Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4302,6 +4316,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Prep for the **0.8.1** release now that full docs are live at
<https://pyglobegl.pages.dev/>.

### Docs / README
- Slim the README (also the PyPI long description) to intro + hero image,
  Installation, Quick start, a **Layers & features** catalogue (each layer/
  integration links to its docs page), a **Documentation** section, and
  Contributing. Removes content now duplicated in the docs site
  (per-layer code blocks, GeoPandas/MovingPandas dumps, runtime-update
  details, goals/roadmap). README 783 → ~140 lines.

### Version
- Bump patch **0.8.0 → 0.8.1** so a release ships the new README to PyPI.

### Flaky test fix
- `test_jupyter_widget_renders` could fail on a missed cell-execution state
  change in CI (flaky across macOS/Windows runners). Re-run the widget cell
  with **stamina** retries instead of just waiting longer; a real cell
  traceback raises `RuntimeError` and is not retried. Adds `stamina` to the
  dev group and a 240s test timeout.

prek passes locally. The Chromium UI test can't run under WSL, so its behaviour
is validated by CI.
