### PR TITLE
chore: drop the redundant @biomejs/biome frontend devDependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,6 @@
 	},
 	"devDependencies": {
 		"@anywidget/vite": "^0.2.2",
-		"@biomejs/biome": "^2.5.1",
 		"@types/node": "^25.9.4",
 		"typescript": "^5.9.3",
 		"vite": "^7.3.6"
@@ -15,9 +14,7 @@
 	"private": true,
 	"scripts": {
 		"build": "vite build",
-		"check": "biome check .",
 		"dev": "vite",
-		"format": "biome format --write .",
 		"preview": "vite preview"
 	},
 	"type": "module",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -21,9 +21,6 @@ importers:
       '@anywidget/vite':
         specifier: ^0.2.2
         version: 0.2.2(vite@7.3.6(@types/node@25.9.4))
-      '@biomejs/biome':
-        specifier: ^2.5.1
-        version: 2.5.1
       '@types/node':
         specifier: ^25.9.4
         version: 25.9.4
@@ -44,59 +41,6 @@ packages:
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
-
-  '@biomejs/biome@2.5.1':
-    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
-    engines: {node: '>=14.21.3'}
-    hasBin: true
-
-  '@biomejs/cli-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@biomejs/cli-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
-    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@biomejs/cli-linux-arm64@2.5.1':
-    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@biomejs/cli-linux-x64-musl@2.5.1':
-    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-
-  '@biomejs/cli-linux-x64@2.5.1':
-    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-
-  '@biomejs/cli-win32-arm64@2.5.1':
-    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
-    engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@biomejs/cli-win32-x64@2.5.1':
-    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [win32]
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -660,41 +604,6 @@ snapshots:
       vite: 7.3.6(@types/node@25.9.4)
 
   '@babel/runtime@7.29.7': {}
-
-  '@biomejs/biome@2.5.1':
-    optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.1
-      '@biomejs/cli-darwin-x64': 2.5.1
-      '@biomejs/cli-linux-arm64': 2.5.1
-      '@biomejs/cli-linux-arm64-musl': 2.5.1
-      '@biomejs/cli-linux-x64': 2.5.1
-      '@biomejs/cli-linux-x64-musl': 2.5.1
-      '@biomejs/cli-win32-arm64': 2.5.1
-      '@biomejs/cli-win32-x64': 2.5.1
-
-  '@biomejs/cli-darwin-arm64@2.5.1':
-    optional: true
-
-  '@biomejs/cli-darwin-x64@2.5.1':
-    optional: true
-
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
-    optional: true
-
-  '@biomejs/cli-linux-arm64@2.5.1':
-    optional: true
-
-  '@biomejs/cli-linux-x64-musl@2.5.1':
-    optional: true
-
-  '@biomejs/cli-linux-x64@2.5.1':
-    optional: true
-
-  '@biomejs/cli-win32-arm64@2.5.1':
-    optional: true
-
-  '@biomejs/cli-win32-x64@2.5.1':
-    optional: true
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true


### PR DESCRIPTION
## What & why

Biome linting/formatting in this repo is enforced **solely** via the
`biomejs/pre-commit` hook (run by `prek run --all-files` locally and in the
`lint` CI job). prek manages its own isolated Biome binary at the pinned hook
rev — it does **not** use `frontend/node_modules`.

The `@biomejs/biome` devDependency and the `check`/`format` pnpm scripts were
scaffolded into the initial skeleton (#2) but nothing in CI or prek invokes
them (`grep` finds no `pnpm run check/format` or `biome …` usage outside
`package.json`). Their only effect was a maintenance surface: the weekly
`pnpm update` kept bumping the devDep to the latest patch (e.g. `^2.5.1`) ahead
of the cooldown-gated hook rev (`v2.5.0`), creating exactly the kind of Biome
version drift the just-merged #71/#73 work set out to tame.

## Changes

- Remove `@biomejs/biome` from `frontend/package.json` `devDependencies`.
- Remove the now-unused `check` (`biome check .`) and `format`
  (`biome format --write .`) scripts.
- Regenerate `frontend/pnpm-lock.yaml` with the CI-pinned **pnpm 10.27.0**
  (`--lockfile-only`), removing the 91 Biome lockfile lines; `lockfileVersion`
  stays `'9.0'`.

`biome.json` is intentionally **kept** — it's the config the prek hook reads.

## Validation

- `pnpm install --frozen-lockfile` consistency check passes (so
  `release.yml`'s frozen install + `pnpm run build` is unaffected — Biome was
  never part of the Vite build).
- `prek run --all-files` passes, including the `biome-check` hook (which lints
  `package.json` itself).
- Confirmed no CI workflow or prek hook referenced the removed scripts.

https://claude.ai/code/session_01SRLGMbaiknGG73sxp6QeyP
