### PR TITLE
chore: release 0.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyglobegl"
-version = "0.9.0"
+version = "0.9.1"
 description = "anywidget wrapper for globe.gl"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3156,7 +3156,7 @@ wheels = [
 
 [[package]]
 name = "pyglobegl"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
Version bump only — 0.9.0 → 0.9.1.

### Why now

#77 put the pandera fix on main but it is unpublished, so released 0.9.0 is still broken for anyone whose resolver picks pandera 0.32.1.

pandera 0.32.1 added pydantic alias support (unionai-oss/pandera#2381) whose halves disagree: `PydanticModel.coerce()` dumps each row with `by_alias=True`, while the schema's inferred placeholder columns still use the model's field names. Every layer model sets `serialization_alias` for its camelCase globe.gl keys, so every `*_from_gdf` helper fails:

```
SchemaError: column 'dash_length' not in dataframe.
Columns in dataframe: [..., 'dashLength', 'dashGap', ...]
```

That is a hard failure across points, paths, polygons, arcs, rings, tiles, labels, particles and hexed polygons — not a degradation.

Note this needs no pandera pin: #77 removed the redundant `PydanticModel` pre-pass entirely, so the helpers no longer depend on the broken behaviour either way.

### Verification

`prek run --all-files` clean; 139 non-browser tests pass locally, and CI runs the full 241 including the browser suite.